### PR TITLE
Refine CLI argument handling and visibility

### DIFF
--- a/shaperglot-cli/src/check.rs
+++ b/shaperglot-cli/src/check.rs
@@ -9,7 +9,7 @@ use std::{
 #[derive(Args)]
 pub struct CheckArgs {
     /// Number of fixes left to be considered nearly supported
-    #[arg(long, default_value_t = 5, conflicts_with = "fix")]
+    #[arg(long, default_value_t = 5, conflicts_with = "fix", hide = true)]
     nearly: usize,
     /// Verbosity
     #[arg(short, long, action = clap::ArgAction::Count, conflicts_with = "json")]

--- a/shaperglot-cli/src/check.rs
+++ b/shaperglot-cli/src/check.rs
@@ -9,16 +9,16 @@ use std::{
 #[derive(Args)]
 pub struct CheckArgs {
     /// Number of fixes left to be considered nearly supported
-    #[arg(long, default_value_t = 5)]
+    #[arg(long, default_value_t = 5, conflicts_with = "fix")]
     nearly: usize,
     /// Verbosity
-    #[arg(short, long, action = clap::ArgAction::Count)]
+    #[arg(short, long, action = clap::ArgAction::Count, conflicts_with = "json")]
     verbose: u8,
     /// Output check results as JSON
     #[arg(long)]
     json: bool,
     /// Output a fix summary
-    #[arg(long)]
+    #[arg(long, conflicts_with = "json")]
     fix: bool,
     /// Font file to check
     font: PathBuf,

--- a/shaperglot-cli/src/check.rs
+++ b/shaperglot-cli/src/check.rs
@@ -9,7 +9,7 @@ use std::{
 #[derive(Args)]
 pub struct CheckArgs {
     /// Number of fixes left to be considered nearly supported
-    #[arg(long, default_value_t = 5, conflicts_with = "fix", hide = true)]
+    #[arg(long, default_value_t = 5, hide = true)]
     nearly: usize,
     /// Verbosity
     #[arg(short, long, action = clap::ArgAction::Count, conflicts_with = "json")]

--- a/shaperglot-cli/src/report.rs
+++ b/shaperglot-cli/src/report.rs
@@ -5,22 +5,22 @@ use std::path::PathBuf;
 #[derive(Args)]
 pub struct ReportArgs {
     /// Number of fixes left to be considered nearly supported
-    #[arg(long, default_value_t = 5)]
+    #[arg(long, default_value_t = 5, hide = true)]
     nearly: usize,
     /// Verbosity
-    #[arg(short, long, action = clap::ArgAction::Count)]
+    #[arg(short, long, action = clap::ArgAction::Count, hide = true)]
     verbose: u8,
     /// Output check results as JSON
-    #[arg(long)]
+    #[arg(long, hide = true)]
     json: bool,
     /// Output check results as CSV
-    #[arg(long)]
+    #[arg(long, hide = true)]
     csv: bool,
     /// Regular expression to filter languages
     #[arg(long)]
     filter: Option<String>,
     /// Output a fix summary
-    #[arg(long)]
+    #[arg(long, hide = true)]
     fix: bool,
     /// Font file to check
     font: PathBuf,


### PR DESCRIPTION
This PR clarifies the intended usage of CLI arguments by making exclusive options more apparent and hiding unimplemented ones.

Could you please confirm if I've understood the intended CLI behavior correctly with these changes?

Before
---

```console
> cargo run -- check --help
Check language support

Usage: shaperglot check [OPTIONS] <FONT> [LANGUAGES]...

Arguments:
  <FONT>          Font file to check
  [LANGUAGES]...  Language to check

Options:
      --nearly <NEARLY>  Number of fixes left to be considered nearly supported [default: 5]
  -v, --verbose...       Verbosity
      --json             Output check results as JSON
      --fix              Output a fix summary
  -h, --help             Print help
  -V, --version          Print version

> cargo run -- report --help
Report language support

Usage: shaperglot report [OPTIONS] <FONT>

Arguments:
  <FONT>  Font file to check

Options:
      --nearly <NEARLY>  Number of fixes left to be considered nearly supported [default: 5]
  -v, --verbose...       Verbosity
      --json             Output check results as JSON
      --csv              Output check results as CSV
      --filter <FILTER>  Regular expression to filter languages
      --fix              Output a fix summary
  -h, --help             Print help
  -V, --version          Print version
```

After
---

```console
> cargo run -- check --help
Check language support

Usage: shaperglot check [OPTIONS] <FONT> [LANGUAGES]...

Arguments:
  <FONT>          Font file to check
  [LANGUAGES]...  Language to check

Options:
  -v, --verbose...  Verbosity
      --json        Output check results as JSON
      --fix         Output a fix summary
  -h, --help        Print help
  -V, --version     Print version

> cargo run -- report --help
Report language support

Usage: shaperglot report [OPTIONS] <FONT>

Arguments:
  <FONT>  Font file to check

Options:
      --filter <FILTER>  Regular expression to filter languages
  -h, --help             Print help
  -V, --version          Print version
```