### PR TITLE
Return error code on failure

### DIFF
--- a/shaperglot-cli/src/check.rs
+++ b/shaperglot-cli/src/check.rs
@@ -35,9 +35,11 @@ pub fn check_command(args: &CheckArgs, language_database: shaperglot::Languages)
         .unwrap();
     let checker = Checker::new(&font_binary).expect("Failed to load font");
     let mut fixes_required = HashMap::new();
+    let mut has_failed = false;
     for language in args.languages.iter() {
         if let Some(language) = language_database.get_language(language) {
             let results = checker.check(language);
+            has_failed = !results.is_nearly_success(args.nearly);
             if args.json {
                 println!("{}", serde_json::to_string(&results).unwrap());
                 continue;
@@ -53,11 +55,15 @@ pub fn check_command(args: &CheckArgs, language_database: shaperglot::Languages)
                 }
             }
         } else {
+            has_failed = true;
             println!("Language not found ({})", language);
         }
     }
     if args.fix {
         show_fixes(&fixes_required);
+    }
+    if has_failed {
+        std::process::exit(1);
     }
 }
 

--- a/shaperglot-cli/src/check.rs
+++ b/shaperglot-cli/src/check.rs
@@ -9,7 +9,7 @@ use std::{
 #[derive(Args)]
 pub struct CheckArgs {
     /// Number of fixes left to be considered nearly supported
-    #[arg(long, default_value_t = 5, hide = true)]
+    #[arg(long, default_value_t = 5)]
     nearly: usize,
     /// Verbosity
     #[arg(short, long, action = clap::ArgAction::Count, conflicts_with = "json")]

--- a/shaperglot-cli/src/describe.rs
+++ b/shaperglot-cli/src/describe.rs
@@ -22,5 +22,6 @@ pub fn describe_command(args: &DescribeArgs, language_database: shaperglot::Lang
         }
     } else {
         println!("Language not found ({})", &args.language);
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
This PR suggests improving how the CLI handles exit codes for scripts.

Currently, even when a check fails, the CLI exits with code `0`. Also, it has "middle" results like `SKIP` `WARN` or `STOP` that are not clear pass/fail states.

This change proposes that if a check truly fails, the CLI should exit with code `1`. While we might not need to return an error code for `WARN` or `STOP` messages, a clear `1` for failures would greatly help scripts understand the CLI's result.

For a "missing language" error, this PR uses exit code `1`. Is `2` better for this specific error?