### PR TITLE
Add missing language to error message

### DIFF
--- a/shaperglot-cli/src/check.rs
+++ b/shaperglot-cli/src/check.rs
@@ -53,7 +53,7 @@ pub fn check_command(args: &CheckArgs, language_database: shaperglot::Languages)
                 }
             }
         } else {
-            println!("Language not found");
+            println!("Language not found ({})", language);
         }
     }
     if args.fix {

--- a/shaperglot-cli/src/describe.rs
+++ b/shaperglot-cli/src/describe.rs
@@ -21,6 +21,6 @@ pub fn describe_command(args: &DescribeArgs, language_database: shaperglot::Lang
             }
         }
     } else {
-        println!("Language not found");
+        println!("Language not found ({})", &args.language);
     }
 }


### PR DESCRIPTION
When `check` is called with multiple languages, adding the language name to the error message clarifies which argument was incorrect. The `describe` function was adjusted for consistency with this format